### PR TITLE
Find and fix code bugs

### DIFF
--- a/components/Button/index.tsx
+++ b/components/Button/index.tsx
@@ -14,7 +14,7 @@ const Button: React.FC<ButtonProps> = ({ text, href, extraClass, targetBlank = f
             href={href}
             className={`${styles.btn} ${extraClass ? extraClass : ''}`}
             target={targetBlank ? '_blank' : '_self'} // Conditionally set target="_blank"
-            rel={targetBlank ? 'noopener noreferrer' : ''} // Add rel attribute for security when using target="_blank"
+            {...(targetBlank ? { rel: 'noopener noreferrer' } : {})} // Only add rel when target is _blank
         >
             {text}
         </Link>

--- a/libs/gsap/index.ts
+++ b/libs/gsap/index.ts
@@ -1,6 +1,9 @@
 import gsap from "gsap";
 import ScrollTrigger from "gsap/dist/ScrollTrigger";
 
-gsap.registerPlugin(ScrollTrigger);
+// Guard plugin registration to client-side only to avoid SSR/window reference issues
+if (typeof window !== "undefined") {
+    gsap.registerPlugin(ScrollTrigger);
+}
 
 export { gsap, ScrollTrigger };


### PR DESCRIPTION
Guard GSAP ScrollTrigger registration for SSR and omit empty `rel` attribute in `Button` component.

---
<a href="https://cursor.com/background-agent?bcId=bc-a94f7cf2-2b54-4daf-9df7-3239ccc62779">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a94f7cf2-2b54-4daf-9df7-3239ccc62779">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

